### PR TITLE
Explicitly set SPI mode to 0 by default.

### DIFF
--- a/Adafruit_GPIO/SPI.py
+++ b/Adafruit_GPIO/SPI.py
@@ -42,6 +42,8 @@ class SpiDev(object):
 		self._device = spidev.SpiDev()
 		self._device.open(port, device)
 		self._device.max_speed_hz=max_speed_hz
+		# Default to mode 0.
+		self._device.mode = 0
 
 	def set_clock_hz(self, hz):
 		"""Set the speed of the SPI clock in hertz.  Note that not all speeds

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ use_setuptools()
 from setuptools import setup, find_packages
 
 setup(name 				= 'Adafruit_GPIO',
-	  version 			= '0.2.0',
+	  version 			= '0.3.0',
 	  author			= 'Tony DiCola',
 	  author_email		= 'tdicola@adafruit.com',
 	  description		= 'Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO libraries.',


### PR DESCRIPTION
Bumping up to version 0.3.0.  No changes were made to any public facing interfaces, the only change is to default to SPI mode 0 to fix potential issues with inconsistently set SPI modes.
