### PR TITLE
Add PWM and MCP230xx support.

### DIFF
--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -64,6 +64,18 @@ class BaseGPIO(object):
 		"""Return true if the specified pin is pulled low."""
 		return self.input(pin) == LOW
 
+	def output_pins(self, pins):
+		"""Set multiple pins high or low at once.  Pins should be a dict of pin
+		name to pin value (HIGH/True for 1, LOW/False for 0).  All provided pins
+		will be set to the given values.
+		"""
+		# General implementation just loops through pins and writes them out
+		# manually.  This is not optimized, but subclasses can choose to implement
+		# a more optimal batch output implementation.  See the MCP230xx class for
+		# example of optimized implementation.
+		for pin, value in pins.iteritems():
+			self.output(pin, value)
+
 
 class RPiGPIOAdapter(BaseGPIO):
 	"""GPIO implementation for the Raspberry Pi using the RPi.GPIO library."""

--- a/Adafruit_GPIO/MCP230xx.py
+++ b/Adafruit_GPIO/MCP230xx.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import math
+
+import Adafruit_GPIO as GPIO
+import Adafruit_GPIO.I2C as I2C
+
+
+class MCP230xxBase(GPIO.BaseGPIO):
+	"""Base class to represent an MCP230xx series GPIO extender.  Is compatible
+	with the Adafruit_GPIO BaseGPIO class so it can be used as a custom GPIO
+	class for interacting with device.
+	"""
+
+	def __init__(self, address, busnum=I2C.get_default_bus()):
+		"""Initialize MCP230xx at specified I2C address and bus number.  If bus
+		is not specified it will default to the appropriate platform detected bus.
+		"""
+		self._i2c = I2C.Device(address, busnum)
+		# Assume starting in ICON.BANK = 0 mode (sequential access).
+		# Compute how many bytes are needed to store count of GPIO.
+		self.gpio_bytes = int(math.ceil(self.NUM_GPIO/8.0))
+		# Buffer register values so they can be changed without reading.
+		self.iodir = [0x00]*self.gpio_bytes  # Default direction to all inputs.
+		self.gppu = [0x00]*self.gpio_bytes  # Default to pullups disabled.
+		self.gpio = [0x00]*self.gpio_bytes
+		# Write current direction and pullup buffer state.
+		self.write_iodir()
+		self.write_gppu()
+
+	def _validate_pin(self, pin):
+		# Raise an exception if pin is outside the range of allowed values.
+		if pin < 0 or pin >= self.NUM_GPIO:
+			raise ValueError('Invalid GPIO value, must be between 0 and {0}.'.format(self.NUM_GPIO))
+
+	def setup(self, pin, value):
+		"""Set the input or output mode for a specified pin.  Mode should be
+		either GPIO.OUT or GPIO.IN.
+		"""
+		self._validate_pin(pin)
+		# Set bit to 1 for input or 0 for output.
+		if value == GPIO.IN:
+			self.iodir[pin/8] |= 1 << (pin%8)
+		elif value == GPIO.OUT:
+			self.iodir[pin/8] &= ~(1 << (pin%8))
+		else:
+			raise ValueError('Unexpected value.  Must be GPIO.IN or GPIO.OUT.')
+		self.write_iodir()
+
+	def output(self, pin, value):
+		"""Set the specified pin the provided high/low value.  Value should be
+		either GPIO.HIGH/GPIO.LOW or a boolean (True = high).
+		"""
+		self._validate_pin(pin)
+		# Set bit on or off.
+		if value:
+			self.gpio[pin/8] |= 1 << (pin%8)
+		else:
+			self.gpio[pin/8] &= ~(1 << (pin%8))
+		# Write GPIO state.
+		self.write_gpio()
+
+	def output_pins(self, pins):
+		"""Set multiple pins high or low at once.  Pins should be a dict of pin
+		name to pin value (HIGH/True for 1, LOW/False for 0).  All provided pins
+		will be set to the given values.
+		"""
+		# Set each changed pin's bit.
+		for pin, value in pins.iteritems():
+			if value:
+				self.gpio[pin/8] |= 1 << (pin%8)
+			else:
+				self.gpio[pin/8] &= ~(1 << (pin%8))
+		# Write GPIO state.
+		self.write_gpio()
+
+	def input(self, pin):
+		"""Read the specified pin and return GPIO.HIGH/True if the pin is pulled
+		high, or GPIO.LOW/False if pulled low.
+		"""
+		self._validate_pin(pin)
+		# Get GPIO state.
+		gpio = self._i2c.readList(self.GPIO, self.gpio_bytes)
+		# Return True if pin's bit is set.
+		return (gpio[pin/8] & 1 << (pin%8)) > 0
+
+	def pullup(self, pin, enabled):
+		"""Turn on the pull-up resistor for the specified pin if enabled is True,
+		otherwise turn off the pull-up resistor.
+		"""
+		self._validate_pin(pin)
+		if enabled:
+			self.gppu[pin/8] |= 1 << (pin%8)
+		else:
+			self.gppu[pin/8] &= ~(1 << (pin%8))
+		self.write_gppu()
+
+	def write_gpio(self, gpio=None):
+		"""Write the specified byte value to the GPIO registor.  If no value
+		specified the current buffered value will be written.
+		"""
+		if gpio is not None:
+			self.gpio = gpio
+		self._i2c.writeList(self.GPIO, self.gpio)
+
+	def write_iodir(self, iodir=None):
+		"""Write the specified byte value to the IODIR registor.  If no value
+		specified the current buffered value will be written.
+		"""
+		if iodir is not None:
+			self.iodir = iodir 
+		self._i2c.writeList(self.IODIR, self.iodir)
+
+	def write_gppu(self, gppu=None):
+		"""Write the specified byte value to the GPPU registor.  If no value
+		specified the current buffered value will be written.
+		"""
+		if gppu is not None:
+			self.gppu = gppu
+		self._i2c.writeList(self.GPPU, self.gppu)
+
+
+class MCP23017(MCP230xxBase):
+	"""MCP23017-based GPIO class with 16 GPIO pins."""
+	# Define number of pins and registor addresses.
+	NUM_GPIO = 16
+	IODIR    = 0x00
+	GPIO     = 0x12
+	GPPU     = 0x0C
+
+	def __init__(self, address=0x20, **kwargs):
+		super(MCP23017, self).__init__(address, **kwargs)
+
+
+class MCP23008(MCP230xxBase):
+	"""MCP23008-based GPIO class with 8 GPIO pins."""
+	# Define number of pins and registor addresses.
+	NUM_GPIO = 8
+	IODIR    = 0x00
+	GPIO     = 0x09
+	GPPU     = 0x06
+
+	def __init__(self, address=0x20, **kwargs):
+		super(MCP23008, self).__init__(address, **kwargs)

--- a/Adafruit_GPIO/PWM.py
+++ b/Adafruit_GPIO/PWM.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import Adafruit_GPIO.Platform as Platform
+
+
+class RPi_PWM_Adapter(object):
+	"""PWM implementation for the Raspberry Pi using the RPi.GPIO PWM library."""
+
+	def __init__(self, rpi_gpio, mode=None):
+		self.rpi_gpio = rpi_gpio
+		# Suppress warnings about GPIO in use.
+		rpi_gpio.setwarnings(False)
+		# Set board or BCM pin numbering.
+		if mode == rpi_gpio.BOARD or mode == rpi_gpio.BCM:
+			rpi_gpio.setmode(mode)
+		elif mode is not None:
+			raise ValueError('Unexpected value for mode.  Must be BOARD or BCM.')
+		else:
+			# Default to BCM numbering if not told otherwise.
+			rpi_gpio.setmode(rpi_gpio.BCM)
+		# Store reference to each created PWM instance.
+		self.pwm = {}
+
+	def start(self, pin, dutycycle, frequency_hz=2000):
+		"""Enable PWM output on specified pin.  Set to intiial percent duty cycle
+		value (0.0 to 100.0) and frequency (in Hz).
+		"""
+		if dutycycle < 0.0 or dutycycle > 100.0:
+			raise ValueError('Invalid duty cycle value, must be between 0.0 to 100.0 (inclusive).')
+		# Make pin an output.
+		self.rpi_gpio.setup(12, self.rpi_gpio.OUT)
+		# Create PWM instance and save a reference for later access.
+		self.pwm[pin] = self.rpi_gpio.PWM(pin, frequency_hz)
+		# Start the PWM at the specified duty cycle.
+		self.pwm[pin].start(dutycycle)
+
+	def set_duty_cycle(self, pin, dutycycle):
+		"""Set percent duty cycle of PWM output on specified pin.  Duty cycle must
+		be a value 0.0 to 100.0 (inclusive).
+		"""
+		if dutycycle < 0.0 or dutycycle > 100.0:
+			raise ValueError('Invalid duty cycle value, must be between 0.0 to 100.0 (inclusive).')
+		if pin not in self.pwm:
+			raise ValueError('Pin {0} is not configured as a PWM.  Make sure to first call start for the pin.'.format(pin))
+		self.pwm[pin].ChangeDutyCycle(dutycycle)
+
+	def set_frequency(self, pin, frequency_hz):
+		"""Set frequency (in Hz) of PWM output on specified pin."""
+		if pin not in self.pwm:
+			raise ValueError('Pin {0} is not configured as a PWM.  Make sure to first call start for the pin.'.format(pin))
+		self.pwm[pin].ChangeFrequency(frequency_hz)
+
+	def stop(self, pin):
+		"""Stop PWM output on specified pin."""
+		if pin not in self.pwm:
+			raise ValueError('Pin {0} is not configured as a PWM.  Make sure to first call start for the pin.'.format(pin))
+		self.pwm[pin].stop()
+		del self.pwm[pin]
+
+
+class BBIO_PWM_Adapter(object):
+	"""PWM implementation for the BeagleBone Black using the Adafruit_BBIO.PWM
+	library.
+	"""
+
+	def __init__(self, bbio_pwm):
+		self.bbio_pwm = bbio_pwm
+
+	def start(self, pin, dutycycle, frequency_hz=2000):
+		"""Enable PWM output on specified pin.  Set to intiial percent duty cycle
+		value (0.0 to 100.0) and frequency (in Hz).
+		"""
+		if dutycycle < 0.0 or dutycycle > 100.0:
+			raise ValueError('Invalid duty cycle value, must be between 0.0 to 100.0 (inclusive).')
+		self.bbio_pwm.start(pin, dutycycle, frequency_hz)
+
+	def set_duty_cycle(self, pin, dutycycle):
+		"""Set percent duty cycle of PWM output on specified pin.  Duty cycle must
+		be a value 0.0 to 100.0 (inclusive).
+		"""
+		if dutycycle < 0.0 or dutycycle > 100.0:
+			raise ValueError('Invalid duty cycle value, must be between 0.0 to 100.0 (inclusive).')
+		self.bbio_pwm.set_duty_cycle(pin, dutycycle)
+
+	def set_frequency(self, pin, frequency_hz):
+		"""Set frequency (in Hz) of PWM output on specified pin."""
+		self.bbio_pwm.set_frequency(pin, frequency_hz)
+
+	def stop(self, pin):
+		"""Stop PWM output on specified pin."""
+		self.bbio_pwm.stop(pin)
+
+
+def get_platform_pwm(**keywords):
+	"""Attempt to return a PWM instance for the platform which the code is being
+	executed on.  Currently supports only the Raspberry Pi using the RPi.GPIO
+	library and Beaglebone Black using the Adafruit_BBIO library.  Will throw an
+	exception if a PWM instance can't be created for the current platform.  The
+	returned PWM object has the same interface as the RPi_PWM_Adapter and
+	BBIO_PWM_Adapter classes.
+	"""
+	plat = Platform.platform_detect()
+	if plat == Platform.RASPBERRY_PI:
+		import RPi.GPIO
+		return RPi_PWM_Adapter(RPi.GPIO, **keywords)
+	elif plat == Platform.BEAGLEBONE_BLACK:
+		import Adafruit_BBIO.PWM
+		return BBIO_PWM_Adapter(Adafruit_BBIO.PWM, **keywords)
+	elif plat == Platform.UNKNOWN:
+		raise RuntimeError('Could not determine platform.')

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup, find_packages
 
-setup(name 				= 'Adafruit_GPIO',
-	  version 			= '0.3.0',
-	  author			= 'Tony DiCola',
-	  author_email		= 'tdicola@adafruit.com',
-	  description		= 'Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO libraries.',
-	  license			= 'MIT',
-	  url				= 'https://github.com/adafruit/Adafruit_Python_GPIO/',
-	  install_requires	= ['spidev'],
-	  packages 			= find_packages())
+setup(name              = 'Adafruit_GPIO',
+      version           = '0.4.0',
+      author            = 'Tony DiCola',
+      author_email      = 'tdicola@adafruit.com',
+      description       = 'Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO libraries.',
+      license           = 'MIT',
+      url               = 'https://github.com/adafruit/Adafruit_Python_GPIO/',
+      install_requires  = ['spidev'],
+      packages          = find_packages())

--- a/test/test_GPIO.py
+++ b/test/test_GPIO.py
@@ -44,6 +44,11 @@ class TestBaseGPIO(unittest.TestCase):
 		self.assertFalse(gpio.is_low(1))
 		self.assertTrue(gpio.is_high(1))
 
+	def test_output_pins(self):
+		gpio = MockGPIO()
+		gpio.output_pins({0: True, 1: False, 7: True})
+		self.assertDictEqual(gpio.pin_written, {0: [1], 1: [0], 7: [1]})
+
 
 class TestRPiGPIOAdapter(unittest.TestCase):
 	def test_setup(self):

--- a/test/test_PWM.py
+++ b/test/test_PWM.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest
+
+from mock import Mock, patch
+
+import Adafruit_GPIO.PWM as PWM
+
+
+class TestRPi_PWM_Adapter(unittest.TestCase):
+	def test_setup(self):
+		rpi_gpio = Mock()
+		pwm = PWM.RPi_PWM_Adapter(rpi_gpio)
+		pwm.start(1, 50)
+		rpi_gpio.PWM.assert_called_with(1, 2000)
+
+	def test_set_duty_cycle_valid(self):
+		rpi_gpio = Mock()
+		pwm = PWM.RPi_PWM_Adapter(rpi_gpio)
+		pwm.start(1, 50)
+		pwm.set_duty_cycle(1, 75)
+		# Implicit verification that no assertion or other error thrown.
+
+	def test_set_duty_cycle_invalid(self):
+		rpi_gpio = Mock()
+		pwm = PWM.RPi_PWM_Adapter(rpi_gpio)
+		pwm.start(1, 50)
+		self.assertRaises(ValueError, pwm.set_duty_cycle, 1, 150)
+		self.assertRaises(ValueError, pwm.set_duty_cycle, 1, -10)
+
+	def test_set_frequency(self):
+		rpi_gpio = Mock()
+		pwm = PWM.RPi_PWM_Adapter(rpi_gpio)
+		pwm.start(1, 50)
+		pwm.set_frequency(1, 1000)
+		# Implicit verification that no assertion or other error thrown.
+
+
+class TestBBIO_PWM_Adapter(unittest.TestCase):
+	def test_setup(self):
+		bbio_pwm = Mock()
+		pwm = PWM.BBIO_PWM_Adapter(bbio_pwm)
+		pwm.start('P9_16', 50)
+		bbio_pwm.start.assert_called_with('P9_16', 50, 2000)
+
+	def test_set_duty_cycle_valid(self):
+		bbio_pwm = Mock()
+		pwm = PWM.BBIO_PWM_Adapter(bbio_pwm)
+		pwm.start('P9_16', 50)
+		pwm.set_duty_cycle('P9_16', 75)
+		bbio_pwm.set_duty_cycle.assert_called_with('P9_16', 75)
+
+	def test_set_duty_cycle_invalid(self):
+		bbio_pwm = Mock()
+		pwm = PWM.BBIO_PWM_Adapter(bbio_pwm)
+		pwm.start('P9_16', 50)
+		self.assertRaises(ValueError, pwm.set_duty_cycle, 'P9_16', 150)
+		self.assertRaises(ValueError, pwm.set_duty_cycle, 'P9_16', -10)
+
+	def test_set_frequency(self):
+		bbio_pwm = Mock()
+		pwm = PWM.BBIO_PWM_Adapter(bbio_pwm)
+		pwm.start('P9_16', 50)
+		pwm.set_frequency('P9_16', 1000)
+		bbio_pwm.set_frequency.assert_called_with('P9_16', 1000)
+
+
+class TestGetPlatformPWM(unittest.TestCase):
+	@patch.dict('sys.modules', {'RPi': Mock(), 'RPi.GPIO': Mock()})
+	@patch('platform.platform', Mock(return_value='Linux-3.10.25+-armv6l-with-debian-7.4'))
+	def test_raspberrypi(self):
+		pwm = PWM.get_platform_pwm()
+		self.assertIsInstance(pwm, PWM.RPi_PWM_Adapter)
+
+	@patch.dict('sys.modules', {'Adafruit_BBIO': Mock(), 'Adafruit_BBIO.PWM': Mock()})
+	@patch('platform.platform', Mock(return_value='Linux-3.8.13-bone47-armv7l-with-debian-7.4'))
+	def test_beagleboneblack(self):
+		pwm = PWM.get_platform_pwm()
+		self.assertIsInstance(pwm, PWM.BBIO_PWM_Adapter)
+
+	@patch('platform.platform', Mock(return_value='Darwin-13.2.0-x86_64-i386-64bit'))
+	def test_otherplatform(self):
+		self.assertRaises(RuntimeError, PWM.get_platform_pwm)


### PR DESCRIPTION
Bumping library version up to 0.4.  No breaking changes were made to the interface of existing classes.  New features include:
- Base GPIO class has a new output_pins() method which allows setting multiple GPIO pins at once.  This is useful with the MCP230xx GPIO extender changes further below as it it improves performance to batch multiple GPIO changes into one update.
- PWM support using the RPi.GPIO and Adafruit_BBIO libraries (with platform detection similar to the GPIO support in the library).
- MCP230xx (MCP23008 and MCP23017) I2C GPIO extender support.  MCP classes have the same interface as other GPIO adapters and can be used anywhere the existing GPIO classes are used.  This allows existing libraries/devices that use the Adafruit_Python_GPIO library to be connected to an MCP GPIO extender without any changes.
