### PR TITLE
simple input_pins() functions to read and return multiple pins

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -380,10 +380,15 @@ class FT232H(GPIO.BaseGPIO):
     def input(self, pin):
         """Read the specified pin and return HIGH/true if the pin is pulled high,
         or LOW/false if pulled low."""
-        if pin < 0 or pin > 15:
+        return self.input_pins([pin])[0]
+
+    def input_pins(self, pins):
+        """Read multiple pins specified in the given list and return list of pin values
+        GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low."""
+        if [pin for pin in pins if pin < 0 or pin > 15]:
             raise ValueError('Pin must be between 0 and 15 (inclusive).')
-        pins = self.mpsse_read_gpio()
-        return ((pins >> pin) & 0x0001) == 1
+        _pins = self.mpsse_read_gpio()
+        return [((_pins >> pin) & 0x0001) == 1 for pin in pins]
 
 
 class SPI(object):

--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -55,6 +55,12 @@ class BaseGPIO(object):
         or LOW/false if pulled low."""
         raise NotImplementedError
 
+    def input_pins(self, pins):
+        """Read multiple pins specified in the given list and return list of pin values
+        GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low.
+        """
+        raise NotImplementedError
+
     def set_high(self, pin):
         """Set the specified pin HIGH."""
         self.output(pin, HIGH)
@@ -171,6 +177,13 @@ class RPiGPIOAdapter(BaseGPIO):
         """
         return self.rpi_gpio.input(pin)
 
+    def input_pins(self, pins):
+        """Read multiple pins specified in the given list and return list of pin values
+        GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low.
+        """
+        # maybe rpi has a mass read...  it would be more efficient to use it if it exists
+        return [self.rpi_gpio.input(pin) for pin in pins]
+
     def add_event_detect(self, pin, edge, callback=None, bouncetime=-1):
         """Enable edge detection events for a particular GPIO channel.  Pin 
         should be type IN.  Edge must be RISING, FALLING or BOTH.  Callback is a
@@ -253,6 +266,13 @@ class AdafruitBBIOAdapter(BaseGPIO):
         or LOW/false if pulled low.
         """
         return self.bbio_gpio.input(pin)
+
+    def input_pins(self, pins):
+        """Read multiple pins specified in the given list and return list of pin values
+        GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low.
+        """
+        # maybe bbb has a mass read...  it would be more efficient to use it if it exists
+        return [self.bbio_gpio.input(pin) for pin in pins]
 
     def add_event_detect(self, pin, edge, callback=None, bouncetime=-1):
         """Enable edge detection events for a particular GPIO channel.  Pin 

--- a/Adafruit_GPIO/MCP230xx.py
+++ b/Adafruit_GPIO/MCP230xx.py
@@ -71,22 +71,17 @@ class MCP230xxBase(GPIO.BaseGPIO):
 
     def output(self, pin, value):
         """Set the specified pin the provided high/low value.  Value should be
-        either GPIO.HIGH/GPIO.LOW or a boolean (True = high).
+        either GPIO.HIGH/GPIO.LOW or a boolean (True = HIGH).
         """
-        self._validate_pin(pin)
-        # Set bit on or off.
-        if value:
-            self.gpio[int(pin/8)] |= 1 << (int(pin%8))
-        else:
-            self.gpio[int(pin/8)] &= ~(1 << (int(pin%8)))
-        # Write GPIO state.
-        self.write_gpio()
+        self.output_pins({pin: value})
 
     def output_pins(self, pins):
         """Set multiple pins high or low at once.  Pins should be a dict of pin
         name to pin value (HIGH/True for 1, LOW/False for 0).  All provided pins
         will be set to the given values.
         """
+        for pin in pins.keys():
+            self._validate_pin(pin)
         # Set each changed pin's bit.
         for pin, value in pins.iteritems():
             if value:

--- a/Adafruit_GPIO/MCP230xx.py
+++ b/Adafruit_GPIO/MCP230xx.py
@@ -50,10 +50,6 @@ class MCP230xxBase(GPIO.BaseGPIO):
         self.write_iodir()
         self.write_gppu()
 
-    def _validate_pin(self, pin):
-        # Raise an exception if pin is outside the range of allowed values.
-        if pin < 0 or pin >= self.NUM_GPIO:
-            raise ValueError('Invalid GPIO value, must be between 0 and {0}.'.format(self.NUM_GPIO))
 
     def setup(self, pin, value):
         """Set the input or output mode for a specified pin.  Mode should be
@@ -69,6 +65,7 @@ class MCP230xxBase(GPIO.BaseGPIO):
             raise ValueError('Unexpected value.  Must be GPIO.IN or GPIO.OUT.')
         self.write_iodir()
 
+
     def output(self, pin, value):
         """Set the specified pin the provided high/low value.  Value should be
         either GPIO.HIGH/GPIO.LOW or a boolean (True = HIGH).
@@ -80,8 +77,7 @@ class MCP230xxBase(GPIO.BaseGPIO):
         name to pin value (HIGH/True for 1, LOW/False for 0).  All provided pins
         will be set to the given values.
         """
-        for pin in pins.keys():
-            self._validate_pin(pin)
+        [self._validate_pin(pin) for pin in pins.keys()]
         # Set each changed pin's bit.
         for pin, value in pins.iteritems():
             if value:
@@ -90,6 +86,7 @@ class MCP230xxBase(GPIO.BaseGPIO):
                 self.gpio[int(pin/8)] &= ~(1 << (int(pin%8)))
         # Write GPIO state.
         self.write_gpio()
+
 
     def input(self, pin):
         """Read the specified pin and return GPIO.HIGH/True if the pin is pulled
@@ -101,12 +98,12 @@ class MCP230xxBase(GPIO.BaseGPIO):
         """Read multiple pins specified in the given list and return list of pin values
         GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low.
         """
-        for pin in pins:
-            self._validate_pin(pin)
+        [self._validate_pin(pin) for pin in pins]
         # Get GPIO state.
         gpio = self._device.readList(self.GPIO, self.gpio_bytes)
         # Return True if pin's bit is set.
         return [(gpio[int(pin/8)] & 1 << (int(pin%8))) > 0 for pin in pins]
+
 
     def pullup(self, pin, enabled):
         """Turn on the pull-up resistor for the specified pin if enabled is True,

--- a/Adafruit_GPIO/MCP230xx.py
+++ b/Adafruit_GPIO/MCP230xx.py
@@ -100,11 +100,18 @@ class MCP230xxBase(GPIO.BaseGPIO):
         """Read the specified pin and return GPIO.HIGH/True if the pin is pulled
         high, or GPIO.LOW/False if pulled low.
         """
-        self._validate_pin(pin)
+        return self.input_pins([pin])[0]
+
+    def input_pins(self, pins):
+        """Read multiple pins specified in the given list and return list of pin values
+        GPIO.HIGH/True if the pin is pulled high, or GPIO.LOW/False if pulled low.
+        """
+        for pin in pins:
+            self._validate_pin(pin)
         # Get GPIO state.
         gpio = self._device.readList(self.GPIO, self.gpio_bytes)
         # Return True if pin's bit is set.
-        return (gpio[int(pin/8)] & 1 << (int(pin%8))) > 0
+        return [(gpio[int(pin/8)] & 1 << (int(pin%8))) > 0 for pin in pins]
 
     def pullup(self, pin, enabled):
         """Turn on the pull-up resistor for the specified pin if enabled is True,

--- a/Adafruit_GPIO/PCF8574.py
+++ b/Adafruit_GPIO/PCF8574.py
@@ -2,21 +2,23 @@
 Adafruit compatible using BaseGPIO class to represent a PCF8574/A IO expander
 Copyright (C) 2015 Sylvan Butler
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-associated documentation files (the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute,
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-'''
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.'''
 
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.I2C as I2C

--- a/Adafruit_GPIO/PCF8574.py
+++ b/Adafruit_GPIO/PCF8574.py
@@ -1,0 +1,101 @@
+'''
+Adafruit compatible using BaseGPIO class to represent a PCF8574/A IO expander
+Copyright (C) 2015 Sylvan Butler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+import Adafruit_GPIO as GPIO
+import Adafruit_GPIO.I2C as I2C
+
+
+
+IN = GPIO.IN
+OUT = GPIO.OUT
+HIGH = GPIO.HIGH
+LOW = GPIO.LOW
+
+
+class PCF8574(GPIO.BaseGPIO):
+    """Class to represent a PCF8574 or PCF8574A GPIO extender. Compatible
+    with the Adafruit_GPIO BaseGPIO class so it can be used as a custom GPIO
+    class for interacting with device.
+    """
+
+    NUM_GPIO = 8
+
+    def __init__(self, address, i2c=None, **kwargs):
+        address = int(address)
+        self.__name__ = \
+            "PCF8574" if address in range(0x20, 0x28) else \
+            "PCF8574A" if address in range(0x38, 0x40) else \
+            "Bad address for PCF8574(A): 0x%02X not in range [0x20..0x27, 0x38..0x3F]" % address
+        if self.__name__[0] != 'P':
+            raise ValueError(self.__name__)
+        # Create I2C device.
+        if i2c is None:
+            i2c = I2C
+        self._device = i2c.get_i2c_device(address, **kwargs)
+        # Buffer register values so they can be changed without reading.
+        self.iodir = 0xFF  # Default direction to all inputs is in
+        self.gpio = 0x00
+        self._write_pins()
+
+
+    def _write_pins(self):
+        self._device.writeRaw8(self.gpio | self.iodir)
+
+    def _read_pins(self):
+        return self._device.readRaw8() & self.iodir
+
+    def _validate_pin(self, pin):
+        # Raise an exception if pin is outside the range of allowed values.
+        if pin < 0 or pin >= self.NUM_GPIO:
+            raise ValueError('Invalid GPIO value, must be between 0 and {0}.'.format(self.NUM_GPIO))
+
+    def _bit2(self, src, bit, val):
+        bit = 1 << bit
+        return (src | bit) if val else (src & ~bit)
+
+
+    def setup(self, pin, mode):
+        self.setup_pins({pin: mode})
+
+    def setup_pins(self, pins):
+        if False in [y for x,y in [(self._validate_pin(pin),mode in (IN,OUT)) for pin,mode in pins.iteritems()]]:
+            raise ValueError('Invalid MODE, IN or OUT')
+        for pin,mode in pins.iteritems():
+            self.iodir = self._bit2(self.iodir, pin, mode)
+        self._write_pins()
+
+
+    def output(self, pin, value):
+        self.output_pins({pin: value})
+
+    def output_pins(self, pins):
+        [self._validate_pin(pin) for pin in pins.keys()]
+        for pin,value in pins.iteritems():
+            self.gpio = self._bit2(self.gpio, pin, bool(value))
+        self._write_pins()
+
+
+    def input(self, pin):
+        return self.input_pins([pin])[0]
+
+    def input_pins(self, pins):
+        [self._validate_pin(pin) for pin in pins]
+        inp = self._read_pins()
+        return [bool(inp & pin) for pin in pins]


### PR DESCRIPTION
Instead of checking input pins one at a time, use input_pins(). Give it a list of pins and it returns the corresponding list of input values. Useful for e.g. reading the R-Pi CharLCD plate buttons more efficiently than looping 'is_pressed()' for each button.

tested and working:
* MCP230xx.py

not tested but should be very close to working:
* FT232H.py implemented using the same pattern as MCP230xx
* GPIO.py has the parent class stubbed NotImplemented and has Rpi and BBB implementations using the underlying single-pin read functions within a simple list comprehension

sdb