### PR TITLE
Compatability and refactoring

### DIFF
--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -19,8 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import Platform as Platform
-
+import Adafruit_GPIO.Platform as Platform
 
 OUT     = 0
 IN      = 1
@@ -374,7 +373,7 @@ class AdafruitMinnowAdapter(BaseGPIO):
 
 def get_platform_gpio(**keywords):
     """Attempt to return a GPIO instance for the platform which the code is being
-    executed on.  Currently supports only the Raspberry Pi using the RPi.GPIO
+    executed on. Currently supports only the Raspberry Pi using the RPi.GPIO
     library, Beaglebone Black using the Adafruit_BBIO library, and
     Minnowboard MAX using the mraa GPIO library.  Will throw an
     exception if a GPIO instance can't be created for the current platform.  The

--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -378,7 +378,7 @@ def get_platform_gpio(**keywords):
         import Adafruit_BBIO.GPIO
         return AdafruitBBIOAdapter(Adafruit_BBIO.GPIO, **keywords)
     elif plat == Platform.MINNOWBOARD:
-        #probably don't need to import the mraa library again (did it in platform.py)
+        import mraa
         return AdafruitMinnowAdapter(mraa, **keywords)
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/SPI.py
+++ b/Adafruit_GPIO/SPI.py
@@ -97,7 +97,7 @@ class SpiDev(object):
 class SpiDevMraa(object):
     """Hardware SPI implementation with the mraa library on Minnowboard"""
     def __init__(self, port, device, max_speed_hz=500000):
-        self._device = mraa.Spi()
+        self._device = mraa.Spi(0)
         self._device.mode(0)
         
     def set_clock_hz(self, hz):
@@ -106,7 +106,7 @@ class SpiDevMraa(object):
         """
         self._device.frequency(hz)
 
-        def set_mode(self,mode):
+    def set_mode(self,mode):
         """Set SPI mode which controls clock polarity and phase.  Should be a
         numeric value 0, 1, 2, or 3.  See wikipedia page for details on meaning:
         http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus

--- a/Adafruit_GPIO/SPI.py
+++ b/Adafruit_GPIO/SPI.py
@@ -97,6 +97,7 @@ class SpiDev(object):
 class SpiDevMraa(object):
     """Hardware SPI implementation with the mraa library on Minnowboard"""
     def __init__(self, port, device, max_speed_hz=500000):
+        import mraa
         self._device = mraa.Spi(0)
         self._device.mode(0)
         


### PR DESCRIPTION
Some of the code requirements for the end user to implement interrupts on wait_for_edge was causing some issues, so it has been moved to the GPIO library to greatly simplify the code on Minnowboard MAX. Here's an example of [waiting on an edge](https://gist.github.com/steelee/d9920d0e3459bcc3df91) using a GPIO pin hooked into a button going back to Minnowboard GPIO pin 25. It changes the function slightly, but still very close in line with the other platforms. 