### PR TITLE
Add python3 support to I2CDevice

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -709,6 +709,21 @@ class I2CDevice(object):
         response = self._transaction_end()
         self._verify_acks(response)
 
+    def readBytes(self, length):
+        """Read a length number of bytes from the bus (without register).  Results
+        will be returned as a bytearray."""
+        if length <= 0:
+            raise ValueError("Length must be at least 1 byte.")
+        self._i2c_idle()
+        self._transaction_start()
+        self._i2c_start()
+        self._i2c_write_bytes([self._address_byte(True)])
+        self._i2c_read_bytes(length)
+        self._i2c_stop()
+        response = self._transaction_end()
+        self._verify_acks(response[:-length])
+        return response[-length:]
+
     def readList(self, register, length):
         """Read a length number of bytes from the specified register.  Results
         will be returned as a bytearray."""


### PR DESCRIPTION
- "byte" strings need to be created differently
- response from read is bytes so _mpsse_sync needs to check for that.
- relative imports are different in python3
- `str(response)` in line 228 works in python2, even without the `str`
