### PR TITLE
Support for the C.H.I.P. Computer

### DIFF
--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -444,7 +444,6 @@ class CHIPGPIOAdapter(BaseGPIO):
         cmd = "echo %d > /sys/class/gpio/export" % self._pin_mapping[pin]
         self.sp.call(cmd, shell=True)
         cmd = "echo \"%s\" > /sys/class/gpio/gpio%d/direction" % (self._dir_mapping[mode], self._pin_mapping[pin])
-        print cmd
         self.sp.Popen(cmd, shell=True)
         self.pins.append(self._pin_mapping[pin])
         self.modes.append(mode)

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -54,8 +54,10 @@ def get_default_bus():
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
     elif plat == Platform.CHIP:
-        # CHIP has 2 user accessible I2C busses, default to 1 (U13_9 and U13_11)
-        return 1
+        # CHIP has 2 user accessible I2C busses, default to 2 (U1425 and U14_26)
+		# The 4.4 Kernel CHIPs remove i2c-1 for the ability to set with a dtb overlay
+		# and therefore isn't accessible without one
+        return 2
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -53,6 +53,9 @@ def get_default_bus():
     elif plat == Platform.BEAGLEBONE_BLACK:
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
+    elif plat == Platform.CHIP:
+        # CHIP has 2 user accessible I2C busses, default to 1 (U13_9 and U13_11)
+        return 1
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 import logging
 import subprocess
+import time
 
 import smbus
 
@@ -104,97 +105,152 @@ class Device(object):
     def writeRaw8(self, value):
         """Write an 8-bit value on the bus (without register)."""
         value = value & 0xFF
-        self._bus.write_byte(self._address, value)
-        self._logger.debug("Wrote 0x%02X",
+        try:
+            self._bus.write_byte(self._address, value)
+            self._logger.debug("Wrote 0x%02X",
                      value)
+        except IOError, err:
+            self._logger.exception("error in writeRaw8: %s", err)
+            time.sleep(0.001)
 
     def write8(self, register, value):
         """Write an 8-bit value to the specified register."""
         value = value & 0xFF
-        self._bus.write_byte_data(self._address, register, value)
-        self._logger.debug("Wrote 0x%02X to register 0x%02X",
+        try:
+            self._bus.write_byte_data(self._address, register, value)
+            self._logger.debug("Wrote 0x%02X to register 0x%02X",
                      value, register)
+        except IOError, err:
+            self._logger.exception("error in write8: %s", err)
+            time.sleep(0.001)
 
     def write16(self, register, value):
         """Write a 16-bit value to the specified register."""
         value = value & 0xFFFF
-        self._bus.write_word_data(self._address, register, value)
-        self._logger.debug("Wrote 0x%04X to register pair 0x%02X, 0x%02X",
+        try:
+            self._bus.write_word_data(self._address, register, value)
+            self._logger.debug("Wrote 0x%04X to register pair 0x%02X, 0x%02X",
                      value, register, register+1)
+        except IOError, err:
+            self._logger.exception("error in write16: %s", err)
+            time.sleep(0.001)
 
     def writeList(self, register, data):
         """Write bytes to the specified register."""
-        self._bus.write_i2c_block_data(self._address, register, data)
-        self._logger.debug("Wrote to register 0x%02X: %s",
+        try:
+            self._bus.write_i2c_block_data(self._address, register, data)
+            self._logger.debug("Wrote to register 0x%02X: %s",
                      register, data)
+        except IOError, err:
+            self._logger.exception("error in writeList: %s", err)
+            time.sleep(0.001)
 
     def readList(self, register, length):
         """Read a length number of bytes from the specified register.  Results
         will be returned as a bytearray."""
-        results = self._bus.read_i2c_block_data(self._address, register, length)
-        self._logger.debug("Read the following from register 0x%02X: %s",
+        try:
+            results = self._bus.read_i2c_block_data(self._address, register, length)
+            self._logger.debug("Read the following from register 0x%02X: %s",
                      register, results)
-        return results
+            return results
+        except IOError, err:
+            self._logger.exception("error in readList: %s", err)
+            time.sleep(0.001)
 
     def readRaw8(self):
         """Read an 8-bit value on the bus (without register)."""
-        result = self._bus.read_byte(self._address) & 0xFF
-        self._logger.debug("Read 0x%02X",
+        try:
+            result = self._bus.read_byte(self._address) & 0xFF
+            self._logger.debug("Read 0x%02X",
                     result)
-        return result
+            return result
+        except IOError, err:
+            self._logger.exception("error in readRaw8: %s", err)
+            time.sleep(0.001)
 
     def readU8(self, register):
         """Read an unsigned byte from the specified register."""
-        result = self._bus.read_byte_data(self._address, register) & 0xFF
-        self._logger.debug("Read 0x%02X from register 0x%02X",
+        try:
+            result = self._bus.read_byte_data(self._address, register) & 0xFF
+            self._logger.debug("Read 0x%02X from register 0x%02X",
                      result, register)
-        return result
+            return result
+        except IOError, err:
+            self._logger.exception("error in readU8: %s", err)
+            time.sleep(0.001)
 
     def readS8(self, register):
         """Read a signed byte from the specified register."""
-        result = self.readU8(register)
-        if result > 127:
-            result -= 256
-        return result
+        try:
+            result = self.readU8(register)
+            if result > 127:
+                result -= 256
+            return result
+        except IOError, err:
+            self._logger.exception("error in readS8: %s", err)
+            time.sleep(0.001)
 
     def readU16(self, register, little_endian=True):
         """Read an unsigned 16-bit value from the specified register, with the
         specified endianness (default little endian, or least significant byte
         first)."""
-        result = self._bus.read_word_data(self._address,register) & 0xFFFF
-        self._logger.debug("Read 0x%04X from register pair 0x%02X, 0x%02X",
+        try:
+            result = self._bus.read_word_data(self._address,register) & 0xFFFF
+            self._logger.debug("Read 0x%04X from register pair 0x%02X, 0x%02X",
                            result, register, register+1)
-        # Swap bytes if using big endian because read_word_data assumes little
-        # endian on ARM (little endian) systems.
-        if not little_endian:
-            result = ((result << 8) & 0xFF00) + (result >> 8)
-        return result
+            # Swap bytes if using big endian because read_word_data assumes little
+            # endian on ARM (little endian) systems.
+            if not little_endian:
+                result = ((result << 8) & 0xFF00) + (result >> 8)
+            return result
+        except IOError, err:
+            self._logger.exception("error in readU16: %s", err)
 
     def readS16(self, register, little_endian=True):
         """Read a signed 16-bit value from the specified register, with the
         specified endianness (default little endian, or least significant byte
         first)."""
-        result = self.readU16(register, little_endian)
-        if result > 32767:
-            result -= 65536
-        return result
+        try:
+            result = self.readU16(register, little_endian)
+            if result > 32767:
+                result -= 65536
+            return result
+        except IOError, err:
+            self._logger.exception("error in readS16: %s", err)
+            time.sleep(0.001)
 
     def readU16LE(self, register):
         """Read an unsigned 16-bit value from the specified register, in little
         endian byte order."""
-        return self.readU16(register, little_endian=True)
+        try:
+            return self.readU16(register, little_endian=True)
+        except IOError, err:
+            self._logger.exception("error in readU16LE: %s", err)
+            time.sleep(0.001)
 
     def readU16BE(self, register):
         """Read an unsigned 16-bit value from the specified register, in big
         endian byte order."""
-        return self.readU16(register, little_endian=False)
+        try:
+            return self.readU16(register, little_endian=False)
+        except IOError, err:
+            self._logger.exception("error in readU16BE: %s", err)
+            time.sleep(0.001)
 
     def readS16LE(self, register):
         """Read a signed 16-bit value from the specified register, in little
         endian byte order."""
-        return self.readS16(register, little_endian=True)
+        try:
+            return self.readS16(register, little_endian=True)
+        except IOError, err:
+            self._logger.exception("error in readS16LE: %s", err)
+            time.sleep(0.001)
 
     def readS16BE(self, register):
         """Read a signed 16-bit value from the specified register, in big
         endian byte order."""
-        return self.readS16(register, little_endian=False)
+        try:
+            return self.readS16(register, little_endian=False)
+        except IOError, err:
+            self._logger.exception("error in readS16BE: %s", err)
+            time.sleep(0.001)

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -56,13 +56,13 @@ def get_default_bus():
         return 1
     elif plat == Platform.CHIP:
         # CHIP has 2 user accessible I2C busses, default to 2 (U1425 and U14_26)
-		# We want the CHIP to default to 2 as the PocketCHIP header breaks out
-		# this interface
-		# But, the CHIP Pro defaults to bus 1
-		import CHIP_IO.Utilities as UT
-		if UT.is_chip_pro():
-		    return 1
-		else:
+        # We want the CHIP to default to 2 as the PocketCHIP header breaks out
+        # this interface
+        # But, the CHIP Pro defaults to bus 1
+        import CHIP_IO.Utilities as UT
+        if UT.is_chip_pro():
+            return 1
+        else:
             return 2
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -56,9 +56,14 @@ def get_default_bus():
         return 1
     elif plat == Platform.CHIP:
         # CHIP has 2 user accessible I2C busses, default to 2 (U1425 and U14_26)
-		# The 4.4 Kernel CHIPs remove i2c-1 for the ability to set with a dtb overlay
-		# and therefore isn't accessible without one
-        return 2
+		# We want the CHIP to default to 2 as the PocketCHIP header breaks out
+		# this interface
+		# But, the CHIP Pro defaults to bus 1
+		import CHIP_IO.Utilities as UT
+		if UT.is_chip_pro():
+		    return 1
+		else:
+            return 2
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 

--- a/Adafruit_GPIO/PWM.py
+++ b/Adafruit_GPIO/PWM.py
@@ -110,7 +110,11 @@ class BBIO_PWM_Adapter(object):
 
 
 class CHIP_PWM_Adapter(object):
-    """PWM implementation for the CHIP using sysfs"""
+    """
+     PWM implementation for the CHIP using sysfs
+      For HW PWM: chipio_pwm = CHIP_IO.PWM
+      For SW PWM: chipio_pwm = CHIP_IO.SOFTPWM
+    """
 
     def __init__(self, chipio_pwm):
         self.chipio_pwm = chipio_pwm
@@ -156,7 +160,14 @@ def get_platform_pwm(**keywords):
         import Adafruit_BBIO.PWM
         return BBIO_PWM_Adapter(Adafruit_BBIO.PWM, **keywords)
     elif plat == Platform.CHIP:
-        import CHIP_IO.PWM
-        return CHIP_PWM_Adapter(CHIP_IO.PWM, **keywords)
+        if "pwmtype" in keywords.keys():
+            if keywords["pwmtype"] == "pwm":
+                import CHIP_IO.PWM
+                return CHIP_PWM_Adapter(CHIP_IO.PWM, **keywords)
+            elif keywords["pwmtype"] == "softpwm":
+                import CHIP_IO.SOFTPWM
+                return CHIP_PWM_Adapter(CHIP_IO.SOFTPWM, **keywords)
+        else:
+            raise ValueError('For CHIP, you need to specify pwmtype in argument with value pwm or softpwm: get_platform_pwm(pwmtype="pwm") or get_platform_type(pwmtype="softpwm")')
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/PWM.py
+++ b/Adafruit_GPIO/PWM.py
@@ -109,6 +109,49 @@ class BBIO_PWM_Adapter(object):
         self.bbio_pwm.stop(pin)
 
 
+def CHIP_PWM_Adapter(object):
+    """PWM implementation for the CHIP using sysfs"""
+
+    def __init__(self):
+        import subprocess as sp
+        self.sp = sp
+
+    def start(self, dutycycle, frequency_hz=2000):
+        """Enable PWM on the CHIP, there is only 1 pin, at the specified duty cycle value (0 to 100)
+           and frequency (in Hz)
+        """
+        # Setup dutycycle
+        if dutycycle < 0.0 or dutycycle > 100.0:
+            raise ValueError('Invalid duty cycle value, must be between 0.0 and 100.0 (inclusive).')
+        cmd = "echo %d > /sys/class/pwm/pwm0/duty_percent" % int(dutycycle)
+        self.sp.call(cmd, shell=True)
+
+        # Setup frequency
+        cmd = "echo %dhz > /sys/class/pwm/pwm0/period" % int(frequency_hz)
+        self.sp.Popen(cmd, shell=True)
+
+        # Enable
+        cmd = "echo 1 > /sys/class/pwm/pwm0/run"
+        self.sp.Popen(cmd, shell=True)
+
+    def set_duty_cycle(self, dutycycle):
+        """Set percent duty cycle of PWM output, value must be between 0.0 and 100.0"""
+        if dutycycle < 0.0 or dutycycle > 100.0:
+            raise ValueError('Invalid duty cycle value, must be between 0.0 and 100.0 (inclusive).')
+        cmd = "echo %d > /sys/class/pwm/pwm0/duty_percent" % int(dutycycle)
+        self.sp.call(cmd, shell=True)
+
+    def set_frequency(self, frequency_hz):
+        """Set frequency (in Hz) of PWM output"""
+        cmd = "echo %dhz > /sys/class/pwm/pwm0/period" % int(frequency_hz)
+        self.sp.Popen(cmd, shell=True)
+
+    def stop(self):
+        """Stop the PWM output"""
+        cmd = "echo 0 > /sys/class/pwm/pwm0/run"
+        self.sp.Popen(cmd, shell=True)
+
+
 def get_platform_pwm(**keywords):
     """Attempt to return a PWM instance for the platform which the code is being
     executed on.  Currently supports only the Raspberry Pi using the RPi.GPIO
@@ -124,5 +167,7 @@ def get_platform_pwm(**keywords):
     elif plat == Platform.BEAGLEBONE_BLACK:
         import Adafruit_BBIO.PWM
         return BBIO_PWM_Adapter(Adafruit_BBIO.PWM, **keywords)
+    elif plat == Platform.CHIP:
+        return CHIP_PWM_Adapter(**keywords)
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/PWM.py
+++ b/Adafruit_GPIO/PWM.py
@@ -163,10 +163,10 @@ def get_platform_pwm(**keywords):
         if "pwmtype" in keywords.keys():
             if keywords["pwmtype"] == "pwm":
                 import CHIP_IO.PWM
-                return CHIP_PWM_Adapter(CHIP_IO.PWM, **keywords)
+                return CHIP_PWM_Adapter(CHIP_IO.PWM)
             elif keywords["pwmtype"] == "softpwm":
                 import CHIP_IO.SOFTPWM
-                return CHIP_PWM_Adapter(CHIP_IO.SOFTPWM, **keywords)
+                return CHIP_PWM_Adapter(CHIP_IO.SOFTPWM)
         else:
             raise ValueError('For CHIP, you need to specify pwmtype in argument with value pwm or softpwm: get_platform_pwm(pwmtype="pwm") or get_platform_type(pwmtype="softpwm")')
     elif plat == Platform.UNKNOWN:

--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -26,6 +26,7 @@ UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
+CHIP             = 5
 
 def platform_detect():
     """Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -34,6 +35,11 @@ def platform_detect():
     pi = pi_version()
     if pi is not None:
         return RASPBERRY_PI
+
+    # Handle CHIP
+    chip = detect_chip()
+    if chip is not None:
+        return CHIP
 
     # Handle Beaglebone Black
     # TODO: Check the Beaglebone Black /proc/cpuinfo value instead of reading
@@ -104,3 +110,24 @@ def pi_version():
     else:
         # Something else, not a pi.
         return None
+
+def detect_chip():
+    """ Detect the CHIP computer from Next Thing Co, this could also be used to other 
+        Allwinner Based SBCs
+    """
+    # Open cpuinfo
+    with open('/proc/cpuinfo','r') as infile:
+        cpuinfo = infile.read()
+    
+    # Match a line like 'Hardware        : Allwinner sun4i/sun5i Families'
+    match = re.search('^Hardware\s+:.*$', cpuinfo,
+                      flags=re.MULTILINE | re.IGNORECASE)
+
+    # Check result
+    if not match:
+        return None
+    if "sun4i/sun5i" in match.group(0):
+        return True
+    else:
+        return None
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Adafruit Python GPIO Library
 ============================
 
-Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the [RPi.GPIO](https://pypi.python.org/pypi/RPi.GPIO) and [Adafruit_BBIO](https://pypi.python.org/pypi/Adafruit_BBIO) libraries.
+Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the [RPi.GPIO](https://pypi.python.org/pypi/RPi.GPIO), [Adafruit_BBIO](https://pypi.python.org/pypi/Adafruit_BBIO), and [CHIP_IO](https://github.com/xtacocorex/CHIP_IO) libraries.
 
 The library is currently in an early stage, but you can see how its used in the [Adafruit Nokia LCD library](https://github.com/adafruit/Adafruit_Nokia_LCD) to write Python code that is easily portable between the Raspberry Pi and Beaglebone Black.
 

--- a/tests/chip_gpio_test.py
+++ b/tests/chip_gpio_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+
+import Adafruit_GPIO as GPIO
+import time, os
+
+print "GETTING GPIO OBJECT"
+gpio = GPIO.get_platform_gpio()
+
+
+print "SETUP CSID1"
+gpio.setup("CSID1", GPIO.OUT)
+
+#print os.path.exists('/sys/class/gpio/gpio133')
+
+print "SETUP XIO-P1"
+gpio.setup("XIO-P1", GPIO.IN)
+#GPIO.setup("U14_13", GPIO.IN)
+
+print "READING XIO-P1"
+gpio.output("CSID1", GPIO.HIGH)
+print "HIGH", gpio.input("XIO-P1")
+
+gpio.output("CSID1", GPIO.LOW)
+time.sleep(1)
+print "LOW", gpio.input("XIO-P1")
+
+gpio.output("CSID1", GPIO.HIGH)
+print "HIGH", gpio.input("XIO-P1")
+time.sleep(1)
+
+gpio.output("CSID1", GPIO.LOW)
+print "LOW", gpio.input("XIO-P1")
+
+print "CLEANUP"
+gpio.cleanup()


### PR DESCRIPTION
This pull request adds support for the CHIP by NextThingCo.  The code is similar to the BeagleBone Black, as I've ported the adafruit_beaglebone_io_python library to the CHIP and called it CHIP_IO.  There are no CHIP HW specifics in this library as I've put everything into CHIP_IO.

The following code has been touched: 
GPIO.py -> Adds a CHIP GPIO Device
Platform.py -> Adds the CHIP to be an allowed platform
I2C.py -> Adds the ability to use get the default CHIP I2C bus
PWM.py -> Adds the ability to get the HW and SW PWM for the CHIP

Limitations:
- HW PWM on the CHIP requires, at the moment, a custom kernel and DTS overlay
- Has not been verified with the Adafruit native i2c and spi library
