### PR TITLE
add support for UP board

### DIFF
--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -347,8 +347,8 @@ class AdafruitBBIOAdapter(BaseGPIO):
         else:
             self.bbio_gpio.cleanup(pin)
 
-class AdafruitMinnowAdapter(BaseGPIO):
-    """GPIO implementation for the Minnowboard + MAX using the mraa library"""
+class AdafruitMraaAdapter(BaseGPIO):
+    """GPIO implementation for the Minnowboard + MAX and UP using the mraa library"""
     
     def __init__(self,mraa_gpio):
         self.mraa_gpio = mraa_gpio
@@ -421,6 +421,9 @@ def get_platform_gpio(**keywords):
         return AdafruitBBIOAdapter(Adafruit_BBIO.GPIO, **keywords)
     elif plat == Platform.MINNOWBOARD:
         import mraa
-        return AdafruitMinnowAdapter(mraa, **keywords)
+        return AdafruitMraaAdapter(mraa, **keywords)
+    elif plat == Platform.UP:
+        import mraa
+        return AdafruitMraaAdapter(mraa, **keywords)
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -51,6 +51,9 @@ def get_default_bus():
     elif plat == Platform.BEAGLEBONE_BLACK:
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
+    elif plat == Platform.UP:
+	# UP board uses I2C bus 1, like Revision 2 Pi
+	return 1
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 

--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -26,6 +26,7 @@ UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
+UP               = 4
 
 def platform_detect():
     """Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -46,12 +47,14 @@ def platform_detect():
     elif plat.lower().find('armv7l-with-glibc2.4') > -1:
         return BEAGLEBONE_BLACK
         
-    # Handle Minnowboard
+    # Handle Minnowboard and UP
     # Assumption is that mraa is installed
     try: 
         import mraa 
         if mraa.getPlatformName()=='MinnowBoard MAX':
             return MINNOWBOARD
+        elif mraa.getPlatformName()=='UP':
+            return UP
     except ImportError:
         pass
     

--- a/Adafruit_GPIO/SPI.py
+++ b/Adafruit_GPIO/SPI.py
@@ -95,7 +95,7 @@ class SpiDev(object):
         return bytearray(self._device.xfer2(data))
 
 class SpiDevMraa(object):
-    """Hardware SPI implementation with the mraa library on Minnowboard"""
+    """Hardware SPI implementation with the mraa library on Minnowboard and UP"""
     def __init__(self, port, device, max_speed_hz=500000):
         import mraa
         self._device = mraa.Spi(0)


### PR DESCRIPTION
This PR adds initial support for the UP board (www.up-board.org).

The UP board is an Intel Atom SoC and has a similar form-factor to the Raspberry Pi, designed to be compatible with many existing Raspberry Pi HATs.

As Intel's MRAA library includes support for UP, and is included by default with the official Linux distribution for the UP board (www.ubilinux.org), this change uses MRAA to identify the UP board in the same way that it is currently used to identify the Minnowboard.
