### PR TITLE
fix i2c_readlist() function and detect whether ftdi driver used before enable/disable it

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -717,15 +717,17 @@ class I2CDevice(object):
         self._idle()
         self._transaction_start()
         self._i2c_start()
-        self._i2c_write_bytes([self._address_byte(True), register])
+        self._i2c_write_bytes([self._address_byte(False), register])
         self._i2c_stop()
         self._i2c_idle()
         self._i2c_start()
+        self._i2c_write_bytes([self._address_byte(True)])
         self._i2c_read_bytes(length)
         self._i2c_stop()
         response = self._transaction_end()
         self._verify_acks(response[:-length])
         return response[-length:]
+
 
     def readRaw8(self):
         """Read an 8-bit value on the bus (without register)."""

--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -60,7 +60,8 @@ def disable_FTDI_driver():
         # Mac OS commands to disable FTDI driver.
         _check_running_as_root()
         subprocess.call('kextunload -b com.apple.driver.AppleUSBFTDI', shell=True)
-        subprocess.call('kextunload /System/Library/Extensions/FTDIUSBSerialDriver.kext', shell=True)
+        if os.path.exists('/System/Library/Extensions/FTDIUSBSerialDriver.kext'):
+            subprocess.call('kextunload /System/Library/Extensions/FTDIUSBSerialDriver.kext', shell=True)
     elif sys.platform.startswith('linux'):
         logger.debug('Detected Linux')
         # Linux commands to disable FTDI driver.
@@ -77,7 +78,8 @@ def enable_FTDI_driver():
         # Mac OS commands to enable FTDI driver.
         _check_running_as_root()
         subprocess.check_call('kextload -b com.apple.driver.AppleUSBFTDI', shell=True)
-        subprocess.check_call('kextload /System/Library/Extensions/FTDIUSBSerialDriver.kext', shell=True)
+        if os.path.exists('/System/Library/Extensions/FTDIUSBSerialDriver.kext'):
+            subprocess.call('kextunload /System/Library/Extensions/FTDIUSBSerialDriver.kext', shell=True)
     elif sys.platform.startswith('linux'):
         logger.debug('Detected Linux')
         # Linux commands to enable FTDI driver.

--- a/libftdi.rb
+++ b/libftdi.rb
@@ -1,0 +1,25 @@
+class Libftdi < Formula
+  desc "Library to talk to FTDI chips"
+  homepage "https://www.intra2net.com/en/developer/libftdi"
+  url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.2.tar.bz2"
+  sha256 "a6ea795c829219015eb372b03008351cee3fb39f684bff3bf8a4620b558488d6"
+
+  bottle do
+    cellar :any
+    sha256 "81690eae8fa778df6a48557d03b154fbb3fe726d27edf8c8cccfb0f440810c46" => :el_capitan
+    sha256 "fe679703a4c73cdae3d5c893c411ae4f080c113c9aef2e7c290c6c7386e2357d" => :yosemite
+    sha256 "4049462256cac963b49c6cb430be7458cfad761af6db42cfef19ac33c8a8eca6" => :mavericks
+  end
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+  depends_on "boost" => :optional
+
+  def install
+    mkdir "libftdi-build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
As we discussed here:
https://github.com/adafruit/Adafruit_Python_GPIO/issues/36

i2c_readlist() function should work with this change.

And most people don't have ftdi driver installed,just add a path exists detect to before load or unload it.
