### PR TITLE
Fix PCF8574 to work with python3 also

### DIFF
--- a/Adafruit_GPIO/PCF8574.py
+++ b/Adafruit_GPIO/PCF8574.py
@@ -23,8 +23,6 @@ SOFTWARE.'''
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.I2C as I2C
 
-
-
 IN = GPIO.IN
 OUT = GPIO.OUT
 HIGH = GPIO.HIGH
@@ -56,34 +54,30 @@ class PCF8574(GPIO.BaseGPIO):
         self.gpio = 0x00
         self._write_pins()
 
-
     def _write_pins(self):
         self._device.writeRaw8(self.gpio | self.iodir)
 
     def _read_pins(self):
         return self._device.readRaw8() & self.iodir
 
-
     def setup(self, pin, mode):
         self.setup_pins({pin: mode})
 
     def setup_pins(self, pins):
-        if False in [y for x,y in [(self._validate_pin(pin),mode in (IN,OUT)) for pin,mode in pins.iteritems()]]:
+        if False in [y for x, y in [(self._validate_pin(pin), mode in (IN, OUT)) for pin, mode in pins.items()]]:
             raise ValueError('Invalid MODE, IN or OUT')
-        for pin,mode in pins.iteritems():
+        for pin, mode in pins.items():
             self.iodir = self._bit2(self.iodir, pin, mode)
         self._write_pins()
-
 
     def output(self, pin, value):
         self.output_pins({pin: value})
 
     def output_pins(self, pins):
         [self._validate_pin(pin) for pin in pins.keys()]
-        for pin,value in pins.iteritems():
+        for pin, value in pins.items():
             self.gpio = self._bit2(self.gpio, pin, bool(value))
         self._write_pins()
-
 
     def input(self, pin):
         return self.input_pins([pin])[0]
@@ -91,4 +85,4 @@ class PCF8574(GPIO.BaseGPIO):
     def input_pins(self, pins):
         [self._validate_pin(pin) for pin in pins]
         inp = self._read_pins()
-        return [bool(inp & (1<<pin)) for pin in pins]
+        return [bool(inp & (1 << pin)) for pin in pins]


### PR DESCRIPTION
I did this change in order to make it work in python3 also.
dict.iteritems() method is only supported on python2,  dict.items() is supported on both versions.