### PR TITLE
Add 1-Wire support to FT232H via GPIO

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -821,7 +821,7 @@ class I2CDevice(object):
         endian byte order."""
         return self.readS16(register, little_endian=False)
 
-class OneWireDevice(object):
+class OneWireMaster(object):
 
     def __init__(self, ft232h, pin, overdrive=False, default_hz=100000, three_phase=True):
         self._pin = pin

--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -923,18 +923,13 @@ class OneWireDevice(object):
             self._ft232h.output(pin, value)
 
         # Calculate the mask for the GPIO when 1-wire is low
-        self._ft232h.setup(self._pin, GPIO.OUT)
-        self._ft232h.output(pin, GPIO.LOW)
+        self._ft232h.setup_pins({self._pin: GPIO.OUT},{self._pin: GPIO.LOW}, write=False)
         self._low = self._ft232h.mpsse_gpio()
 
         # Calculate the mask for the GPIO when 1-wire is high
-        self._ft232h.setup(self._pin, GPIO.IN)
-        self._ft232h.output(pin, GPIO.HIGH)
+        self._ft232h.setup_pins({self._pin: GPIO.IN},{self._pin: GPIO.HIGH}, write=False)
         self._high = self._ft232h.mpsse_gpio()
 
-        # Let the GPIO settle
-        time.sleep(0.1)
-    
     # Here begins the 1-wire stuff
 
     # Send a 1-wire reset on the GPIO, This makes all slaves listen up for commands.


### PR DESCRIPTION
This change adds a OneWireDevice class to the FT232H module and enables support for 1-wire devices via GPIO bit-banging. 

Rather than attempt to handle the 1-wire timings directly in python (and at the mercy of the kernel scheduler), we write command pipelines to the MPSSE, and it handles the high low transitions to perform RESET, WRITE-1, WRITE-0, and READ.

The code includes the option for 1-wire "overdrive" speeds, but I have not tested this personally. I'm using this code to talk to a digital thermometer (DS18b20) which only supports standard mode timings.

The GPIO pin used for 1-wire needs to have a pull-up resistor to the 5v line. I used a 4k7. 1-Wire devices can operate in parasite power mode where they charge themselves directly from the data line. I have tested both powered and parasite modes with my thermometer.