### PR TITLE
Add pine64 platform support

### DIFF
--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -52,8 +52,13 @@ def get_default_bus():
     elif plat == Platform.BEAGLEBONE_BLACK:
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
+    elif plat == Platform.PINE64:
+        # Pine64 has 2 i2c busses, bus0 is used for touchscreen, bus1 is on the pi2 connector.
+        return 1
+
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
+
 
 def get_i2c_device(address, busnum=None, i2c_interface=None, **kwargs):
     """Return an I2C device for the specified address and on the specified bus.

--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -26,6 +26,7 @@ UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
+PINE64           = 4
 
 def platform_detect():
     """Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -54,6 +55,10 @@ def platform_detect():
             return MINNOWBOARD
     except ImportError:
         pass
+    
+    # Handle Pine64
+    if plat.lower().find('pine64') > -1:
+        return PINE64
     
     # Couldn't figure out the platform, just return unknown.
     return UNKNOWN

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Adafruit Python GPIO Library
 ============================
 
-Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the [RPi.GPIO](https://pypi.python.org/pypi/RPi.GPIO) and [Adafruit_BBIO](https://pypi.python.org/pypi/Adafruit_BBIO) libraries.
+Library to provide a cross-platform GPIO interface on the Raspberry Pi, Pine64, and Beaglebone Black using the [RPi.GPIO](https://pypi.python.org/pypi/RPi.GPIO) and [Adafruit_BBIO](https://pypi.python.org/pypi/Adafruit_BBIO) libraries.
 
 The library is currently in an early stage, but you can see how its used in the [Adafruit Nokia LCD library](https://github.com/adafruit/Adafruit_Nokia_LCD) to write Python code that is easily portable between the Raspberry Pi and Beaglebone Black.
 

--- a/tests/test_I2C.py
+++ b/tests/test_I2C.py
@@ -175,6 +175,12 @@ class TestGetDefaultBus(unittest.TestCase):
         bus = I2C.get_default_bus()
         self.assertEqual(bus, 1)
 
+    @patch('Adafruit_GPIO.Platform.platform_detect', Mock(return_value=Platform.PINE64))
+    def test_pine64(self):
+        I2C = safe_import_i2c()
+        bus = I2C.get_default_bus()
+        self.assertEqual(bus, 1)
+        
     @patch('Adafruit_GPIO.Platform.platform_detect', Mock(return_value=Platform.UNKNOWN))
     def test_unknown(self):
         I2C = safe_import_i2c()

--- a/tests/test_Platform.py
+++ b/tests/test_Platform.py
@@ -30,11 +30,17 @@ class TestPlatformDetect(unittest.TestCase):
     def test_beaglebone_black(self):
         result = Platform.platform_detect()
         self.assertEquals(result, Platform.BEAGLEBONE_BLACK)
-
+                          
+    @patch('platform.platform', Mock(return_value='Linux-3.10.107-pine64-aarch64-with-Ubuntu-16.04-xenial'))
+    def test_pine64(self):
+        result = Platform.platform_detect()
+        self.assertEquals(result, Platform.PINE64)
+        
     @patch('platform.platform', Mock(return_value='Darwin-13.2.0-x86_64-i386-64bit'))
     def test_unknown(self):
         result = Platform.platform_detect()
         self.assertEquals(result, Platform.UNKNOWN)
+        
 
 
 class TestPiRevision(unittest.TestCase):


### PR DESCRIPTION
Hello,
Simple additions to Platform and I2c files to add support for Pine64.
I am now happily hacking away using a BMP280 breakout board and the associated adafruit library running on my Pine64.

Respectfully,
Henry Irvine