### PR TITLE
Change platform detect to use /proc/cpuinfo to detect board type and add new board to detect.

### DIFF
--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -20,12 +20,14 @@
 # SOFTWARE.
 import platform
 import re
+import os
 
 # Platform identification constants.
 UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
+GIANT_BOARD      = 4
 
 def platform_detect():
     """Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -38,13 +40,13 @@ def platform_detect():
     # Handle Beaglebone Black
     # TODO: Check the Beaglebone Black /proc/cpuinfo value instead of reading
     # the platform.
-    plat = platform.platform()
-    if plat.lower().find('armv7l-with-debian') > -1:
+	command = 'cat /proc/cpuinfo'
+    plat = os.popen(command).read().strip()
+
+    if plat.lower().find('generic am33xx') > -1:
         return BEAGLEBONE_BLACK
-    elif plat.lower().find('armv7l-with-ubuntu') > -1:
-        return BEAGLEBONE_BLACK
-    elif plat.lower().find('armv7l-with-glibc2.4') > -1:
-        return BEAGLEBONE_BLACK
+	elif plat.lower().find('atmel sama5') > -1:
+        return GIANT_BOARD
         
     # Handle Minnowboard
     # Assumption is that mraa is installed

--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -40,7 +40,7 @@ def platform_detect():
     # Handle Beaglebone Black
     # TODO: Check the Beaglebone Black /proc/cpuinfo value instead of reading
     # the platform.
-	command = 'cat /proc/cpuinfo'
+    command = 'cat /proc/cpuinfo'
     plat = os.popen(command).read().strip()
 
     if plat.lower().find('generic am33xx') > -1:


### PR DESCRIPTION
This PR changes how boards are detected by using "/proc/cpuinfo" instead of reading the platform. This change checks for the processor type and determines the board based on that. This should allow for more boards to be added and detected for use with adafruit-blinka.

**Changes**:
- added 'import os'
- removed all extra beaglebone elif's as they aren't needed anymore
- added GIANT_BOARD to the list of boards.

**limitations**:
- Boards with the same processor will be indistinguishable 

**Test code**:
```
import os

# Platform identification constants.
UNKNOWN          = 0
RASPBERRY_PI     = 1
BEAGLEBONE_BLACK = 2
MINNOWBOARD      = 3
GIANT_BOARD      = 4

command = 'cat /proc/cpuinfo'
plat = os.popen(command).read().strip()

def return_platform():
    if plat.lower().find('generic am33xx') > -1:
        return BEAGLEBONE_BLACK
    elif plat.lower().find('atmel sama5') > -1:
        return GIANT_BOARD

print(return_platform())
```

