### PR TITLE
Allow basic support for libFTDI1.3

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -185,7 +185,10 @@ class FT232H(GPIO.BaseGPIO):
         #else:
         #	logger.debug('Modem status error {0}'.format(ret))
         length = len(string)
-        ret = ftdi.write_data(self._ctx, string, length)
+        try:
+            ret = ftdi.write_data(self._ctx, string, length)
+        except TypeError:
+            ret = ftdi.write_data(self._ctx, string); #compatible with libFtdi 1.3
         # Log the string that was written in a python hex string format using a very
         # ugly one-liner list comprehension for brevity.
         #logger.debug('Wrote {0}'.format(''.join(['\\x{0:02X}'.format(ord(x)) for x in string])))


### PR DESCRIPTION
Between libFTDI versions 1.2 and 1.3. The largest difference is a simple syntax difference on one function, where they removed one of the three arguments. Simply try the one for <=1.2, and if that throws a TypeError, try the syntax for 1.3+

here is a screenshot:
https://www.dropbox.com/s/m7a1ybx3ss2jotg/Screenshot%202019-03-11%2021.30.17.png?dl=0

This change is present in another commit, but with other changes. I am hoping that this simpler commit can be accepted easily...

Signed-off-by: Michael Pratt <mpratt51@gmail.com>