### PR TITLE
setup.py: use the routine modern method for initial install ensuring of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
+ensurepip
+
+#try the following if ensurepip is not sufficient
+#ensurepip --upgrade
+#pip install --upgrade pip setuptools
+
 try:
     # Try using ez_setup to install setuptools if not already installed.
     from ez_setup import use_setuptools


### PR DESCRIPTION
My suggestion for fixing the deprecated method for installing or updating setuptools using ez_setup.py
Also ensures that both pip and setuptools are 'bootstrapped' to the python environment, which does not always happen on a fresh install in Windows.

Fixes #96 

This can be made more robust by detecting if pip or setuptools is installed with `pip --version`, etc...

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
