### PR TITLE
Fix previous pull request for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,28 @@
-ensurepip
-
-#try the following if ensurepip is not sufficient
-#ensurepip --upgrade
-#pip install --upgrade pip setuptools
-
-try:
-    # Try using ez_setup to install setuptools if not already installed.
-    from ez_setup import use_setuptools
-    use_setuptools()
-except ImportError:
-    # Ignore import error and assume Python 3 which already has setuptools.
-    pass
-
-from setuptools import setup, find_packages
+print 'THIS INSTALL SCRIPT MAY REQUIRE ROOT/ADMIN PERMISSIONS'
+print 'Especially if you installed python for "all users"'
+print 'try the following in command prompt if ensurepip is not sufficient'
+print '$ python -m ensurepip --upgrade'
+print '$ python -m pip install --upgrade pip setuptools'
 
 import sys
+try:
+    import pip
+    from setuptools import setup, find_packages
+except ImportError:
+    import ensurepip
+    ensurepip.version()
+    ensurepip.bootstrap()
+    from setuptools import setup, find_packages
 
 # Define required packages.
 requires = ['adafruit-pureio']
+
 # Assume spidev is required on non-windows & non-mac platforms (i.e. linux).
 if sys.platform != 'win32' and sys.platform != 'darwin':
     requires.append('spidev')
 
 setup(name              = 'Adafruit_GPIO',
-      version           = '1.0.3',
+      version           = '1.0.4',
       author            = 'Tony DiCola',
       author_email      = 'tdicola@adafruit.com',
       description       = 'Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO libraries.',


### PR DESCRIPTION
doing a better job than #96 

prints possible requirement for root or admin privileges
tries to import pip before calling ensurepip (which isnt needed for python 3)

this time, don't even keep the method from ez_setup.py, there's no point...
commenting it out with ''' ''' gave me an IOError

bump version because why not?
