### PR TITLE
Fix improper assertion of Chip Select during GPIO pin setup

### DIFF
--- a/Adafruit_GPIO/FT232H.py
+++ b/Adafruit_GPIO/FT232H.py
@@ -31,7 +31,6 @@ import ftdi1 as ftdi
 
 import Adafruit_GPIO.GPIO as GPIO
 
-
 logger = logging.getLogger(__name__)
 
 FT232H_VID = 0x0403   # Default FTDI FT232H vendor ID
@@ -41,7 +40,6 @@ MSBFIRST = 0
 LSBFIRST = 1
 
 _REPEAT_DELAY = 4
-
 
 def _check_running_as_root():
     # NOTE: Checking for root with user ID 0 isn't very portable, perhaps
@@ -122,7 +120,6 @@ def enumerate_device_serials(vid=FT232H_VID, pid=FT232H_PID):
             ftdi.list_free(device_list)
         if ctx is not None:
             ftdi.free(ctx)
-
 
 class FT232H(GPIO.BaseGPIO):
     # Make GPIO constants that match main GPIO class for compatibility.
@@ -333,8 +330,9 @@ class FT232H(GPIO.BaseGPIO):
             self._direction &= ~(1 << pin) & 0xFFFF
             self._level     &= ~(1 << pin) & 0xFFFF
         else:
-            # Set the direction of the pin to 1.
+            # Set the direction and level of the pin to 1.
             self._direction |= (1 << pin) & 0xFFFF
+            self._level     |= (1 << pin) & 0xFFFF
 
     def setup(self, pin, mode):
         """Set the input or output mode for a specified pin.  Mode should be
@@ -392,14 +390,12 @@ class FT232H(GPIO.BaseGPIO):
         _pins = self.mpsse_read_gpio()
         return [((_pins >> pin) & 0x0001) == 1 for pin in pins]
 
-
 class SPI(object):
     def __init__(self, ft232h, cs=None, max_speed_hz=1000000, mode=0, bitorder=MSBFIRST):
         self._ft232h = ft232h
         # Initialize chip select pin if provided to output high.
         if cs is not None:
             ft232h.setup(cs, GPIO.OUT)
-            ft232h.set_high(cs)
         self._cs = cs
         # Initialize clock, mode, and bit order.
         self.set_clock_hz(max_speed_hz)


### PR DESCRIPTION
This is a more direct fix of #53 
Also, cleaned up empty lines

I have tested the change from #53 and it is true that Chip Select currently drops LOW during setup() method. I realized, however, that it starts out HIGH before that (when you first power on the FT232H, aka idle state), so instead of using the set_high() method to make sure it's HIGH, there must be a way to keep it in that state while it is being set as an output pin....

related reading:
general idea in section 4.5 of AN_135: MPSSE Basics
https://www.ftdichip.com/Support/Documents/AppNotes/AN_135_MPSSE_Basics.pdf

commands described in section 3.6 of AN_108: Command Processor for MPSSE
https://www.ftdichip.com/Support/Documents/AppNotes/AN_108_Command_Processor_for_MPSSE_and_MCU_Host_Bus_Emulation_Modes.pdf

In fact, the idle state of pins on the board is from 2.1V to 2.7V for idle HIGH and right after the GPIO assignment command passes, it jumps to either -0.02V for active LOW or 2.9V for active HIGH.
In a debug session you see this occur right after ftd1.write_data(*args), from FT232H.write()

The setup method leads to the mpsse_gpio method which writes direction and level state to the FTDI. That method sets every GPIO at the same time using two commands
0x80: describes the values of pins, and direction in or out, for those pins to be set to low
0x82: describes the values of pins, and direction in or out, for those pins to be set to high

Bottom line: we shouldn't need two separate methods to simply keep the default state of the CS pin to high

So when looking at the code that develops this command and arguments into a single string, _setup_pin(self, pin, mode), it looks like there's a line missing, which to me would be the proper fix. After this change, all GPIO pins set to output are HIGH by default. This allows the line with method set_high() to no longer be necessary for the '__init__' method for SPI. 

So again, adding this line prevents CS from jumping to LOW and then HIGH during the '__init__' method of SPI. I am assuming that there is no reason that output GPIOs should not default to HIGH in any other use case. After all, if a pin is being used by another use case, that would also have its own methods to further take control of the pins....

I don't know if there is a reason for this, but there is a missing line to define the default state of Output pins.
This behavior matches exactly with the power-up or idle of the FT232H before it is accessed by the library at all, where all pins are originally set to HIGH

Tested on my own FT232H breakout with Python 2.7, using debug to step into the SPI instantiation line of one of my scripts.

Signed-off-by: Michael Pratt <mpratt51@gmail.com>