### PR TITLE
Adding support for the Nvidia Jetson Nano Board

### DIFF
--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -424,6 +424,6 @@ def get_platform_gpio(**keywords):
         return AdafruitMinnowAdapter(mraa, **keywords)
     elif plat == Platform.JETSON_NANO:
         import Jetson.GPIO
-          return RPiGPIOAdapter(Jetson.GPIO, **keywords)
+        return RPiGPIOAdapter(Jetson.GPIO, **keywords)
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/GPIO.py
+++ b/Adafruit_GPIO/GPIO.py
@@ -422,5 +422,8 @@ def get_platform_gpio(**keywords):
     elif plat == Platform.MINNOWBOARD:
         import mraa
         return AdafruitMinnowAdapter(mraa, **keywords)
+    elif plat == Platform.JETSON_NANO:
+        import Jetson.GPIO
+          return RPiGPIOAdapter(Jetson.GPIO, **keywords)
     elif plat == Platform.UNKNOWN:
         raise RuntimeError('Could not determine platform.')

--- a/Adafruit_GPIO/Platform.py
+++ b/Adafruit_GPIO/Platform.py
@@ -26,6 +26,7 @@ UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
+JETSON_NANO       = 4
 
 def platform_detect():
     """Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -45,6 +46,8 @@ def platform_detect():
         return BEAGLEBONE_BLACK
     elif plat.lower().find('armv7l-with-glibc2.4') > -1:
         return BEAGLEBONE_BLACK
+    elif plat.lower().find('tegra-aarch64-with-ubuntu') > -1:
+        return JETSON_NANO
         
     # Handle Minnowboard
     # Assumption is that mraa is installed


### PR DESCRIPTION
The Nvidia Jetson Nano has released the PIP plugin Jetson.GPIO which is API compatible with the Rpi.GPIO.

The changes here have been tested with the Nvidia Jetson Nano board and was able to successfully communicate with a 128x64 OLED board.