### PR TITLE
Fix runtime error on using I2C on Jetson Nano

### DIFF
--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -53,6 +53,9 @@ def get_default_bus():
     elif plat == Platform.BEAGLEBONE_BLACK:
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
+    elif plat == Platform.JETSON_NANO:
+        # Jetson Nano has multiple I2C buses, default to 1 (Pin3 and Pin5).
+        return 1
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 


### PR DESCRIPTION
This PR fixes an error which occurs using I2C on Jetson Nano.

Error:
```
RuntimeError: Could not determine default I2C bus for the platform.
```

An conditional branch to `I2C.py` which depends on  74365514d1e40bd1f831cc5230e5b128b0ed7660(#102) has been added.

I run a test on my original I2C device and PCA9685 was able to use on this code.
This is the test code for PCA9685 based on [simpletest.py](https://github.com/adafruit/Adafruit_Python_PCA9685/blob/master/examples/simpletest.py):
```python
import time
import Adafruit_PCA9685
import logging

logging.basicConfig(level=logging.DEBUG)
pwm = Adafruit_PCA9685.PCA9685(0x70)
pwm.set_pwm_freq(60)
while True:
    pwm.set_pwm(0, 0, 0)
    time.sleep(1)
    pwm.set_pwm(0, 0, 2048)
    time.sleep(1)
```